### PR TITLE
Fix undeclared function name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ function checkEven(x) {
   return x % 2 === 0
 }
 
-const evenSchema = v.custom(isEven)
+const evenSchema = v.custom(checkEven)
 const checkPositiveEvenNumber = v(v.and(v.number, v.positive, evenSchema))
 
 // same as


### PR DESCRIPTION
Hi @whiteand, nice library! This README is quite awesome.

`isEven` was not declared in the snippet, but `checkEven` was, so I just made a tiny rename.